### PR TITLE
Add a new function to help print out Diff3 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Or if you need to support even older browsers like Internet Explorer, fetch the 
 * [3-way diff and merging](#3-way-diff-and-merging)
   * [diff3Merge](#diff3Merge)
   * [merge](#merge)
+  * [mergeDiff3](#mergeDiff3)
   * [mergeDigIn](#mergeDigIn)
   * [diff3MergeRegions](#diff3MergeRegions)
 * [2-way diff and patching](#2-way-diff-and-patching)
@@ -138,6 +139,59 @@ const result = r.result;
 //   'z',
 //   '99'
 //  ]
+```
+
+&nbsp;
+
+<a name="mergeDiff3" href="#mergeDiff3">#</a> <i>Diff3</i>.<b>mergeDiff3</b>(<i>a</i>, <i>o</i>, <i>b</i>, <i>options</i>)
+
+Passes arguments to [diff3Merge](#diff3Merge) to generate a diff3-style merge result with original (similar to [git-diff3](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging)).
+
+See examples: https://github.com/bhousel/node-diff3/blob/main/test/mergeDiff3.test.js
+
+```js
+const r = Diff3.mergeDiff3(a, o, b, { label: { a: 'a', o: 'o', b: 'b' } });
+const result = r.result;
+// [
+//   'AA',
+//   '<<<<<<< a',
+//   'a',
+//   'b',
+//   'c',
+//   '||||||| o',
+//   '=======',
+//   'a',
+//   'd',
+//   'c',
+//   '>>>>>>> b',
+//   'ZZ',
+//   '<<<<<<< a',
+//   'new',
+//   '00',
+//   'a',
+//   'a',
+//   '||||||| o',
+//   '00',
+//   '=======',
+//   '11',
+//   '>>>>>>> b',
+//   'M',
+//   'z',
+//   'z',
+//   '99'
+//  ]
+```
+
+Extra options:
+```js
+{
+  // labels for conflict marker lines
+  label: {
+    a: 'a',
+    o: 'o',
+    b: 'b'
+  },
+}
 ```
 
 &nbsp;

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,12 +110,9 @@ export type IRegion<T> = IStableRegion<T> | IUnstableRegion<T>;
  */
 export function diff3MergeRegions<T>(a: T[], o: T[], b: T[]): IRegion<T>[];
 
-export interface IMergeOkRegion<T> {
-  ok: T[];
-}
-
-export interface IMergeConflictRegion<T> {
-  conflict: {
+export interface MergeRegion<T> {
+  ok?: T[];
+  conflict?: {
     a: T[];
     aIndex: number;
     b: T[];
@@ -125,7 +122,10 @@ export interface IMergeConflictRegion<T> {
   };
 }
 
-export type MergeRegion<T> = IMergeOkRegion<T> | IMergeConflictRegion<T>;
+export interface MergeResult {
+  conflict: boolean;
+  result: string[];
+}
 
 export interface IMergeOptions {
   excludeFalseConflicts?: boolean;
@@ -156,11 +156,24 @@ export function merge<T>(
   o: string | T[],
   b: string | T[],
   options?: IMergeOptions
-): string[];
+): MergeResult;
+
+export function mergeDiff3<T>(
+  a: string | T[],
+  o: string | T[],
+  b: string | T[],
+  options?: IMergeOptions & {
+    label?: {
+      a?: string;
+      o?: string;
+      b?: string;
+    }
+  }
+): MergeResult;
 
 export function mergeDigIn<T>(
   a: string | T[],
   o: string | T[],
   b: string | T[],
   options?: IMergeOptions
-): string[];
+): MergeResult;

--- a/index.mjs
+++ b/index.mjs
@@ -5,6 +5,7 @@ export {
   diffPatch,
   diff3MergeRegions,
   diff3Merge,
+  mergeDiff3,
   merge,
   mergeDigIn,
   patch,
@@ -384,6 +385,39 @@ function diff3Merge(a, o, b, options) {
   return results;
 }
 
+function mergeDiff3(a, o, b, options) {
+  let defaults = {
+    excludeFalseConflicts: true,
+    stringSeparator: /\s+/,
+    label: {}
+  };
+  options = Object.assign(defaults, options);
+
+  const mergeResult = diff3Merge(a, o, b, options);
+
+  let conflict = false;
+  let lines = [];
+
+  mergeResult.forEach(result => {
+    if (result.ok) {
+      lines = lines.concat(result.ok);
+    } else if (result.conflict) { 
+      conflict = true;
+      lines.push(`<<<<<<<${options.label.a ? ` ${options.label.a}` : ''}`);
+      lines = lines.concat(result.conflict.a);
+      lines.push(`|||||||${options.label.o ? ` ${options.label.o}` : ''}`);
+      lines = lines.concat(result.conflict.o);
+      lines.push('=======');
+      lines = lines.concat(result.conflict.b);
+      lines.push(`>>>>>>>${options.label.b ? ` ${options.label.b}` : ''}`);
+    }
+  });
+
+  return {
+    conflict: conflict,
+    result: lines
+  };
+}
 
 function merge(a, o, b, options) {
   let defaults = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-diff3",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "repository": "bhousel/node-diff3",
   "description": "A node.js module for text diffing and three-way-merge.",

--- a/test/mergeDiff3.test.js
+++ b/test/mergeDiff3.test.js
@@ -1,0 +1,73 @@
+const test = require('tap').test;
+const Diff3 = require('..');
+
+test('mergeDiff3', function(t) {
+
+  t.test('performs merge diff3 on arrays', function(t) {
+    const o = ['AA', 'ZZ', '00', 'M', '99'];
+    const a = ['AA', 'a', 'b', 'c', 'ZZ', 'new', '00', 'a', 'a', 'M', '99'];
+    const b = ['AA', 'a', 'd', 'c', 'ZZ', '11', 'M', 'z', 'z', '99'];
+    const result = Diff3.mergeDiff3(a, o, b, { label: { a: 'a', o: 'o', b: 'b' } });
+
+    /*
+    AA
+    <<<<<<< a
+    a
+    b
+    c
+    ||||||| o
+    =======
+    a
+    d
+    c
+    >>>>>>> b
+    ZZ
+    <<<<<<< a
+    new
+    00
+    a
+    a
+    ||||||| o
+    00
+    =======
+    11
+    >>>>>>> b
+    M
+    z
+    z
+    99
+    */
+
+    t.same(result.conflict, true);
+    t.same(result.result[0], 'AA');
+    t.same(result.result[1], '<<<<<<< a');
+    t.same(result.result[2], 'a');
+    t.same(result.result[3], 'b');
+    t.same(result.result[4], 'c');
+    t.same(result.result[5], '||||||| o');
+    t.same(result.result[6], '=======');
+    t.same(result.result[7], 'a');
+    t.same(result.result[8], 'd');
+    t.same(result.result[9], 'c');
+    t.same(result.result[10], '>>>>>>> b');
+    t.same(result.result[11], 'ZZ');
+    t.same(result.result[12], '<<<<<<< a');
+    t.same(result.result[13], 'new');
+    t.same(result.result[14], '00');
+    t.same(result.result[15], 'a');
+    t.same(result.result[16], 'a');
+    t.same(result.result[17], '||||||| o');
+    t.same(result.result[18], '00');
+    t.same(result.result[19], '=======');
+    t.same(result.result[20], '11');
+    t.same(result.result[21], '>>>>>>> b');
+    t.same(result.result[22], 'M');
+    t.same(result.result[23], 'z');
+    t.same(result.result[24], 'z');
+    t.same(result.result[25], '99');
+
+    t.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
This aims to create a function like `merge` but for `diff3` which is similar to [git-diff3](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging) format where you show the common ancestor/original as well.
I also corrected the type definitions to make this more convenient for `Typescript` users

@bhousel regarding #38, if you're good with this PR, can you do a release?

Again, thank you so much for this great library!