### PR TITLE
ensure Typescript properly resolve typings in ESM resolution mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,13 @@
   "main": "./dist/index.cjs",
   "module": "./index.mjs",
   "exports": {
-    "import": "./index.mjs",
-    "require": "./dist/index.cjs"
+    ".": {
+      "import": {
+        "default": "./index.mjs",
+        "types": "./index.d.ts"
+      },
+      "require": "./dist/index.cjs"
+    }
   },
   "scripts": {
     "all": "run-s clean test",


### PR DESCRIPTION
Hi @bhousel,

I recently upgraded our codebase to use the Typescript new [moduleResolution mode](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js)

With the current specification of `exports` and `types` fields in `package.json`, we would get the following error

<img width="910" alt="Screen Shot 2022-06-02 at 2 59 05 PM" src="https://user-images.githubusercontent.com/13574879/171713352-5c326e42-bca5-42f5-91cd-ce28975f11e4.png">

To fix this, we can follow the [official guide](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing). I have tested locally by patching `node-diff3` `package.json` file in `node_modules` and the problem is resolved. Really hope you could merge and publish this so I don't have to hack my local in order to use `node-diff3` 🙏 Thank you so much!

 
