### PR TITLE
re-arrange typings ESM exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./index.mjs",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
       },
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
This fixes a small issue introduced by #57 
@bhousel really sorry, I just tested the change in #57 with `Typescript` and not `Webpack`. Today, we found out that by not placing the `default` export at the bottom of the list would cause `webpack` to throw (not warn) the following error.
 
<img width="1081" alt="Screen Shot 2022-06-06 at 3 28 19 PM" src="https://user-images.githubusercontent.com/13574879/172233213-cb66aaa9-5389-455c-9c5a-b77ef9c3ab1c.png">

Could we release this as well, thank you so much and sorry for the trouble 🙏 