### PR TITLE
Fix ICommResult type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,14 @@ export interface ILCSResult {
  */
 export function LCS<T>(buffer1: T[], buffer2: T[]): ILCSResult;
 
-export interface ICommResult<T> {
+export interface IDiff<T> {
   buffer1: T[];
   buffer2: T[];
 }
+export interface ICommon<T> {
+  common: T[]
+}
+export type ICommResult<T> = IDiff<T> | ICommon<T>
 
 /**
  * We apply the LCS to build a 'comm'-style picture of the


### PR DESCRIPTION
`diffComm` actually returns an array of `{ buffer1, buffer2 }` OR `{ common }` items.